### PR TITLE
Fixed init(frame:) EXC_BAD_ACCESS crash

### DIFF
--- a/B68UIFloatLabelTextField/B68UIFloatLabelTextField.swift
+++ b/B68UIFloatLabelTextField/B68UIFloatLabelTextField.swift
@@ -68,8 +68,8 @@ public class B68UIFloatLabelTextField: UITextField {
   //MARK: Initializer
   //MARK: Programmatic Initializer
   
-  override convenience init(frame: CGRect) {
-    self.init(frame: frame)
+  override init(frame: CGRect) {
+    super.init(frame: frame)
     setup()
   }
   


### PR DESCRIPTION
Crash occurred during init of textField from code with frame. 
