### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ I implemented the pattern in SWIFT and enabled some of the internal propertiers 
 #### Manual
 Just clone and add ```B68UIFloatLabelTextField.swift``` to your project.
 
-#### Cocoapods
-- Make sure that your Cocoapods version is >= 0.36: `pod --version`
+#### CocoaPods
+- Make sure that your CocoaPods version is >= 0.36: `pod --version`
 - If not, update it: `sudo gem install cocoapods`
 - `pod init` in you project root dir
 - `nano Podfile`, add:
@@ -36,7 +36,7 @@ use_frameworks!
 
 
 ####Requirements
-- iOS 7.0+ (8.0+ if you use Cocoapods)
+- iOS 7.0+ (8.0+ if you use CocoaPods)
 - Xcode 6.3
 - Swift 1.2 
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
